### PR TITLE
Initial version

### DIFF
--- a/src/mainnet/target-assets/fortETH.sol
+++ b/src/mainnet/target-assets/fortETH.sol
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// ███████╗░█████╗░██████╗░████████╗██████╗░███████╗░██████╗░██████╗
+// ██╔════╝██╔══██╗██╔══██╗╚══██╔══╝██╔══██╗██╔════╝██╔════╝██╔════╝
+// █████╗░░██║░░██║██████╔╝░░░██║░░░██████╔╝█████╗░░╚█████╗░╚█████╗░
+// ██╔══╝░░██║░░██║██╔══██╗░░░██║░░░██╔══██╗██╔══╝░░░╚═══██╗░╚═══██╗
+// ██║░░░░░╚█████╔╝██║░░██║░░░██║░░░██║░░██║███████╗██████╔╝██████╔╝
+// ╚═╝░░░░░░╚════╝░╚═╝░░╚═╝░░░╚═╝░░░╚═╝░░╚═╝╚══════╝╚═════╝░╚═════╝░
+// ███████╗██╗███╗░░██╗░█████╗░███╗░░██╗░█████╗░███████╗
+// ██╔════╝██║████╗░██║██╔══██╗████╗░██║██╔══██╗██╔════╝
+// █████╗░░██║██╔██╗██║███████║██╔██╗██║██║░░╚═╝█████╗░░
+// ██╔══╝░░██║██║╚████║██╔══██║██║╚████║██║░░██╗██╔══╝░░
+// ██║░░░░░██║██║░╚███║██║░░██║██║░╚███║╚█████╔╝███████╗
+// ╚═╝░░░░░╚═╝╚═╝░░╚══╝╚═╝░░╚═╝╚═╝░░╚══╝░╚════╝░╚══════╝
+                                                                                    
+
+// Github - https://github.com/FortressFinance
+
+import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
+import {IAssetVault} from "./interfaces/IAssetVault.sol";
+import {ERC4626, ERC20, FixedPointMathLib} from "src/shared/interfaces/ERC4626.sol";
+
+abstract contract FortETH is ReentrancyGuard, ERC4626 {
+
+    using FixedPointMathLib for uint256;
+    using SafeERC20 for IERC20;
+    
+    struct Fees {
+        /// @notice The performance fee percentage to take for platform on harvest
+        uint256 platformFeePercentage;
+        /// @notice The percentage of fee to pay for caller on harvest
+        uint256 harvestBountyPercentage;
+        /// @notice The fee percentage to take on withdrawal. Fee stays in the vault, and is therefore distributed to vault participants. Used as a mechanism to protect against mercenary capital
+        uint256 withdrawFeePercentage;
+    }
+
+    /// @notice The fees settings
+    Fees public fees;
+
+    /// @notice The internal accounting of AUM
+    uint256 internal totalAUM;
+    /// @notice The internal accounting of the deposit limit. Denominated in shares
+    uint256 public depositCap;
+
+    /// @notice The description of the vault
+    string public description;
+
+    /// @notice The address of owner
+    address public owner;
+    /// @notice The address of recipient of platform fee
+    address public platform;
+
+
+    /// @notice Whether deposits are paused
+    bool public pauseDeposit = false;
+    /// @notice Whether withdrawals are paused
+    bool public pauseWithdraw = false;
+
+    /// @notice The fee denominator
+    uint256 internal constant DENOMINATOR = 1e9;
+    /// @notice The maximum withdrawal fee
+    uint256 internal constant MAX_WITHDRAW_FEE = 1e8; // 10%
+    /// @notice The maximum platform fee
+    uint256 internal constant MAX_PLATFORM_FEE = 2e8; // 20%
+    /// @notice The maximum harvest fee
+    uint256 internal constant MAX_HARVEST_BOUNTY = 1e8; // 10%
+
+
+    /// @notice The address of WETH token.
+    address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
+    /// @notice The mapping of whitelisted feeless redeemers
+    mapping(address => bool) public feelessRedeemerWhitelist;
+
+    /// @notice The mapping of AssetVaults addresses to assets
+    /// @dev AssetVaults are standalone contracts that hold the assets
+    mapping(address => address) public assetVaults;
+    /// @dev AssetWeigth is a proportion deposited asssets are distributed between assetVaults
+    uint32[] public assetWeights;
+    /// @notice The list of addresses of AssetVaults
+    address[] public assetVaultList;
+
+    /********************************** Constructor **********************************/
+
+    constructor(
+            string memory _name,
+            string memory _symbol,
+            string memory description,
+            address _owner,
+            address _platform,
+        )
+        ERC4626(ERC20(WETH), "Fortress LSDs Primitive", "fortETH") {
+
+        {
+            Fees storage _fees = fees;
+            _fees.platformFeePercentage = 50000000; // 5%
+            _fees.harvestBountyPercentage = 25000000; // 2.5%
+            _fees.withdrawFeePercentage = 2000000; // 0.2%
+        }
+        
+        owner = _owner;
+        platform = _platform;
+        depositCap = 0;
+    }
+
+    /********************************** View Functions **********************************/
+
+    /// @dev Get the name of the vault
+    /// @return - The name of the vault
+    function getName() external view returns (string memory) {
+        return name;
+    }
+
+    /// @dev Get the symbol of the vault
+    /// @return - The symbol of the vault
+    function getSymbol() external view returns (string memory) {
+        return symbol;
+    }
+
+    /// @dev Get the description of the vault
+    /// @return - The description of the vault
+    function getDescription() external view returns (string memory) {
+        return description;
+    }
+
+    /// @dev Allows an on-chain or off-chain user to simulate the effects of their redeemption at the current block, given current on-chain conditions
+    /// @param _shares - The amount of _shares to redeem
+    /// @return - The amount of _assets in return, after subtracting a withdrawal fee
+    function previewRedeem(uint256 _shares) public view override returns (uint256) {
+        // Calculate assets based on a user's % ownership of vault shares
+        uint256 assets = convertToAssets(_shares);
+
+        uint256 _totalSupply = totalSupply;
+
+        // Calculate a fee - zero if user is the last to withdraw
+        uint256 _fee = (_totalSupply == 0 || _totalSupply - _shares == 0) ? 0 : assets.mulDivDown(fees.withdrawFeePercentage, DENOMINATOR);
+
+        // Redeemable amount is the post-withdrawal-fee amount
+        return assets - _fee;
+    }
+
+    /// @dev Allows an on-chain or off-chain user to simulate the effects of their withdrawal at the current block, given current on-chain conditions
+    /// @param _assets - The amount of _assets to withdraw
+    /// @return - The amount of shares to burn, after subtracting a fee
+    function previewWithdraw(uint256 _assets) public view override returns (uint256) {
+        // Calculate shares based on the specified assets' proportion of the pool
+        uint256 _shares = convertToShares(_assets);
+
+        uint256 _totalSupply = totalSupply;
+
+        // Factor in additional shares to fulfill withdrawal if user is not the last to withdraw
+        return (_totalSupply == 0 || _totalSupply - _shares == 0) ? _shares : (_shares * DENOMINATOR) / (DENOMINATOR - fees.withdrawFeePercentage);
+    }
+
+    /// @dev Returns the total amount of assets that are managed by the vault
+    /// @return - The total amount of managed assets
+    function totalAssets() public view virtual override returns (uint256) {
+        return totalAUM;
+    }
+
+    /// @dev Returns the maximum amount of the underlying asset that can be deposited into the Vault for the receiver, through a deposit call
+    function maxDeposit(address) public view override returns (uint256) {
+        uint256 _assetCap = convertToAssets(depositCap);
+        return _assetCap == 0 ? type(uint256).max : _assetCap - totalAUM;
+    }
+
+    /// @dev Returns the maximum amount of the Vault shares that can be minted for the receiver, through a mint call
+    function maxMint(address) public view override returns (uint256) {
+        return depositCap == 0 ? type(uint256).max : depositCap - totalSupply;
+    }
+
+    /********************************** Mutated Functions **********************************/
+
+    /// @dev Mints Vault shares to _receiver by depositing exact amount of underlying assets
+    /// @param _assets - The amount of assets to deposit
+    /// @param _receiver - The receiver of minted shares
+    /// @return _shares - The amount of shares minted
+    function deposit(uint256 _assets, address _receiver) external override nonReentrant returns (uint256 _shares) {
+        if (_assets >= maxDeposit(msg.sender)) revert InsufficientDepositCap();
+
+        _shares = previewDeposit(_assets);
+        
+        _deposit(msg.sender, _receiver, _assets, _shares);
+
+        IERC20(address(asset)).safeTransferFrom(msg.sender, address(this), _assets);
+        
+        _distributeAssets(_assets);
+
+        return _shares;
+    }
+
+    /// @dev Mints exact Vault shares to _receiver by depositing amount of underlying assets
+    /// @param _shares - The shares to receive
+    /// @param _receiver - The address of the receiver of shares
+    /// @return _assets - The amount of underlying assets received
+    function mint(uint256 _shares, address _receiver) external override nonReentrant returns (uint256 _assets) {
+        if (_shares >= maxMint(msg.sender)) revert InsufficientDepositCap();
+
+        _assets = previewMint(_shares);
+
+        _deposit(msg.sender, _receiver, _assets, _shares);
+
+        IERC20(address(asset)).safeTransferFrom(msg.sender, address(this), _assets);
+        
+        _distributeAssets(_assets);
+
+        return _assets;
+    }
+
+    /// @dev Distribute buffered WETH between AssetVaults
+    function distributeBufferedAssets(address _receiver, uint256 _minBounty) external nonReentrant {
+        uint256 bufferedBalance = ERC20(WETH).balanceOf(address(this));
+        if (!bufferedBalance>0) revert ZeroAmount();
+
+        uint256 _harvestBounty = _fees.harvestBountyPercentage;
+        if (_harvestBounty > 0) {
+                _harvestBounty = (_harvestBounty * bufferedBalance) / DENOMINATOR;
+                if (!(_harvestBounty >= _minBounty)) revert InsufficientAmountOut();
+                
+                IERC20(WETH).safeTransfer(_receiver, _harvestBounty);
+            }
+         _distributeAssets(bufferedBalance - _harvestBounty);
+    }
+
+    /// @dev Burns shares from owner and sends exact assets of underlying assets to _receiver. If the _owner is whitelisted, no withdrawal fee is applied
+    /// @param _assets - The amount of underlying assets to receive
+    /// @param _receiver - The address of the receiver of underlying assets
+    /// @param _owner - The owner of shares
+    /// @return _shares - The amount of shares burned
+    function withdraw(uint256 _assets, address _receiver, address _owner) external override nonReentrant returns (uint256 _shares) {}
+     
+
+    /// @dev Burns exact shares from owner and sends assets of underlying tokens to _receiver. If the _owner is whitelisted, no withdrawal fee is applied
+    /// @param _shares - The shares to burn
+    /// @param _receiver - The address of the receiver of underlying assets
+    /// @param _owner - The owner of shares to burn
+    /// @return _assets - The amount of assets returned to the user
+    function redeem(uint256 _shares, address _receiver, address _owner) external override nonReentrant returns (uint256 _assets) {}
+       
+    /// @dev Adds emitting of YbTokenTransfer event to the original function
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        balanceOf[msg.sender] -= amount;
+
+        // Cannot overflow because the sum of all user
+        // balances can't exceed the max uint256 value.
+        unchecked {
+            balanceOf[to] += amount;
+        }
+
+        emit Transfer(msg.sender, to, amount);
+        emit YbTokenTransfer(msg.sender, to, amount, convertToAssets(amount));
+        
+        return true;
+    }
+
+    /// @dev Adds emitting of YbTokenTransfer event to the original function
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        uint256 allowed = allowance[from][msg.sender]; // Saves gas for limited approvals.
+
+        if (allowed != type(uint256).max) allowance[from][msg.sender] = allowed - amount;
+
+        balanceOf[from] -= amount;
+
+        // Cannot overflow because the sum of all user
+        // balances can't exceed the max uint256 value.
+        unchecked {
+            balanceOf[to] += amount;
+        }
+
+        emit Transfer(from, to, amount);
+        emit YbTokenTransfer(from, to, amount, convertToAssets(amount));
+
+        return true;
+    }
+
+    /// @dev Updates AUM according to assetVault actual ETH denominated balances
+    function updateAUM() public returns (uint256 totalAUM) {
+        totalAUM = ERC20(WETH).balanceOf(address(this));
+        uint256 length = assetVaultList.length;
+        
+        for(uint256 i = 0; i < length;) {
+            address assetVault = assetVaultList[i];
+            totalAUM += IAssetVault(_assetVault).getEthBalance();
+            unchecked{ ++i; }
+        }
+        return totalAUM;
+    }
+
+    /********************************** Restricted Functions **********************************/
+
+    /// @inheritdoc IMetaVault
+    function addAssetVault(address _assetVault, address _targetAsset, uint32 _weight) external nonReentrant returns (bool) {
+        if (msg.sender != owner) revert Unauthorized();
+        if (_weight > 1e9) revert WeightExcess();
+
+        assetVaults[_assetVault] = _targetAsset;
+        assetWeights.push(_weight);
+        assetVaultList.push(_assetVault);
+
+        emit AssetVaultAdded(_assetVault, _targetAsset);
+
+        return true;
+    }
+
+    /// @dev Update assetVault weights 
+    function updateAssetWeights(uint32[] memory newWeights) internal {
+        uint256 length = assetVaultList.length;
+        
+        if (newWeights.length != length) revert LengthNotMatch();
+
+        for (uint256 i = 0; i < length;) {
+            assetWeights[i] = newWeights[i];
+            unchecked{ ++i; }
+        }
+    }
+
+    /// TODO
+    /// @dev Withdraw assets from assetVaults and deposite them back in accordance with assetWeigths
+    // function redistributeAssets() {}
+    
+
+    /// @dev Updates the feelessRedeemerWhitelist
+    /// @param _address - The address to update
+    /// @param _whitelist - The new whitelist status
+    function updateFeelessRedeemerWhitelist(address _address, bool _whitelist) external {
+        if (msg.sender != owner) revert Unauthorized();
+
+        feelessRedeemerWhitelist[_address] = _whitelist;
+    }
+
+    /// @dev Updates the vault fees
+    /// @param _withdrawFeePercentage - The new withdrawal fee percentage
+    /// @param _platformFeePercentage - The new platform fee percentage
+    /// @param _harvestBountyPercentage - The new harvest fee percentage
+    function updateFees(uint256 _withdrawFeePercentage, uint256 _platformFeePercentage, uint256 _harvestBountyPercentage) external {
+        if (msg.sender != owner) revert Unauthorized();
+        if (_withdrawFeePercentage > MAX_WITHDRAW_FEE) revert InvalidAmount();
+        if (_platformFeePercentage > MAX_PLATFORM_FEE) revert InvalidAmount();
+        if (_harvestBountyPercentage > MAX_HARVEST_BOUNTY) revert InvalidAmount();
+
+        Fees storage _fees = fees;
+        _fees.withdrawFeePercentage = _withdrawFeePercentage;
+        _fees.platformFeePercentage = _platformFeePercentage;
+        _fees.harvestBountyPercentage = _harvestBountyPercentage;
+
+        emit UpdateFees(_withdrawFeePercentage, _platformFeePercentage, _harvestBountyPercentage);
+    }
+
+    /// @dev updates the vault settings
+    /// @param _platform - The Fortress platform address
+    /// @param _owner - The vault owner address
+    /// @param _depositCap - The deposit cap
+    function updateSettings(address _platform, address _owner, uint256 _depositCap) external {
+        if (msg.sender != owner) revert Unauthorized();
+
+        platform = _platform;
+        owner = _owner;
+        depositCap = _depositCap;
+
+        emit UpdateInternalUtils();
+    }
+
+    /// @dev Pauses deposits/withdrawals for the vault
+    /// @param _pauseDeposit - The new deposit status
+    /// @param _pauseWithdraw - The new withdraw status
+    function pauseInteractions(bool _pauseDeposit, bool _pauseWithdraw) external {
+        if (msg.sender != owner) revert Unauthorized();
+
+        pauseDeposit = _pauseDeposit;
+        // pauseWithdraw = _pauseWithdraw;
+        
+        emit PauseInteractions(_pauseDeposit, _pauseWithdraw);
+    }
+
+    /// @notice WIP
+    /// @dev Converts assets of assetVault to WETH and sends to fortETH contract 
+    function returnAssets(address _assetVault) external {
+        if (msg.sender != owner) revert Unauthorized();
+
+        _balance = IAssetVault(_assetVault).getPrimaryAssetBalance();
+        _amount = IAssetVault(_assetVault).withdraw(_amount);
+
+        emit AssetsReturn(_assetVault, _amount);
+    }
+
+    /********************************** Internal Functions **********************************/
+
+    function _deposit(address _caller, address _receiver, uint256 _assets, uint256 _shares) internal override {
+        if (pauseDeposit) revert DepositPaused();
+        if (_receiver == address(0)) revert ZeroAddress();
+        if (!(_assets > 0)) revert ZeroAmount();
+        if (!(_shares > 0)) revert ZeroAmount();
+
+        _mint(_receiver, _shares);
+        totalAUM += _assets;
+
+        emit Deposit(_caller, _receiver, _assets, _shares);
+    }
+
+    function _depositAssetVault(address _assetVault, uint256 _amount) internal nonReentrant returns (uint256) {
+        
+        if (assetVaults[_assetVault] == address(0)) revert AssetVaultNotAvailable();
+
+        _approve(address(asset), _assetVault, _amount);
+        _amount = IAssetVault(_assetVault).deposit(_amount);
+        
+        emit AssetDeposited(_assetVault, _asset, _amount);
+
+        return _amount;
+    }
+    
+    function _distributeAssets(uint256 _amount) internal nonReentrant {
+        
+        uint256 length = assetVaultList.length;
+        
+        uint256 totalWeight;
+        
+        if (length == 0) revert NoAssetVaults();
+        
+        for(uint256 i = 0; i < length;) {
+            address assetVault = assetVaultList[i];
+            uint256 assetWeight = uint256(assetWeights[assetVault]);
+            totalWeight += assetWeight;
+            if (totalWeight > 1e9) revert WeightExcess();
+            uint256 depositedAsset = _assets.mul(assetWeight).div(DENOMINATOR);
+            _depositAssetVault(assetVault, depositedAsset);
+            unchecked{ ++i; }
+        } 
+    }
+    
+    function _withdraw(address _caller, address _receiver, address _owner, uint256 _assets, uint256 _shares) internal override {}
+
+
+    /********************************** Events **********************************/
+
+    event Deposit(address indexed _caller, address indexed _receiver, uint256 _assets, uint256 _shares);
+    event Withdraw(address indexed _caller, address indexed _receiver, address indexed _owner, uint256 _assets, uint256 _shares);
+    event YbTokenTransfer(address indexed _caller, address indexed _receiver, uint256 _assets, uint256 _shares);
+    event UpdateFees(uint256 _withdrawFeePercentage, uint256 _platformFeePercentage, uint256 _harvestBountyPercentage);
+    event PauseInteractions(bool _pauseDeposit, bool _pauseWithdraw);
+    event UpdateInternalUtils();
+    
+    /********************************** Errors **********************************/
+
+    error Unauthorized();
+    error InsufficientBalance();
+    error InsufficientAllowance();
+    error InvalidAmount();
+    error InsufficientDepositCap();
+    error ZeroAddress();
+    error ZeroAmount();
+    error InsufficientAmountOut();
+    error DepositPaused();
+    error WithdrawPaused();
+    error WeightExcess();
+    error NoAssetVaults();
+    error AssetVaultNotAvailable();
+    error LengthNotMatch();
+}

--- a/src/mainnet/target-assets/interfaces/IAssetVault.sol
+++ b/src/mainnet/target-assets/interfaces/IAssetVault.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IAssetVault {
+
+    /// @notice Enum to represent the current state of the vault
+    /// @dev INITIAL = Right after deployment, can move to `UNMANAGED` by calling 'initVault'
+    /// @dev UNMANAGED = Users are able to interact with the vault, can move to `MANAGED` by calling 'startEpoch'
+    /// @dev MANAGED = Strategies will be able to borrow & repay, can move to `UNMANAGED` by calling 'endEpoch'
+    enum State {
+        INITIAL,
+        UNMANAGED,
+        MANAGED
+    }
+
+    /********************************** View Functions **********************************/
+
+    /// @dev Indicates whether the AssetVault is active, i.e. if it has assets under management
+    /// @return True if the AssetVault is active, false otherwise
+    function isActive() external view returns (bool);
+
+    /// @dev Indicates whether assets are deployed in a specific strategy
+    /// @param _strategy The address of the strategy
+    /// @return True if assets are deployed in the strategy, false otherwise
+    function isStrategyActive(address _strategy) external view returns (bool);
+
+    /// @dev Indicates whether assets are deployed in any strategy
+    /// @return True if assets are deployed in any strategy, false otherwise
+    function areStrategiesActive() external view returns (bool);
+
+    /// @dev Returns the address of the VaultAsset asset
+    function getAsset() external view returns (address);
+
+    /********************************** Meta Vault Functions **********************************/
+
+    /// @dev Deposits assets into the AssetVault. Can only be called by the MetaVault
+    /// @param _amount The amount of assets to deposit, in metaVaultAsset
+    /// @return _amountIn The amount of assets deposited, in asset
+    function deposit(uint256 _amount) external returns (uint256 _amountIn);
+
+    /// @dev Withdraws assets from the AssetVault. Can only be called by the MetaVault
+    /// @param _amount The amount of assets to withdraw, in asset
+    /// @return _amountOut amount of assets withdrawn, in metaVaultAsset
+    function withdraw(uint256 _amount) external returns (uint256 _amountOut);
+
+
+    /// @dev Override the stratagies status of the AssetVault. Can only be called by the platform
+    /// @param _isStrategiesActive The new status of the strategies
+    function overrideActiveStatus(bool _isStrategiesActive) external;
+
+    /********************************** Events **********************************/
+
+    /// @notice Emitted when a deposit is made
+    /// @param _timestamp The timestamp of the deposit
+    /// @param _amount The amount of assets deposited
+    event Deposited(uint256 indexed _timestamp, uint256 _amount);
+
+    /// @notice Emitted when a withdrawal is made
+    /// @param _timestamp The timestamp of the withdrawal
+    /// @param _amount The amount of assets withdrawn
+    event Withdrawn(uint256 indexed _timestamp, uint256 _amount);
+
+    /// @notice Emitted when assets are deposited into a strategy
+    /// @param _timestamp The timestamp of the deposit
+    /// @param _strategy The address of the strategy
+    /// @param _amount The amount of assets deposited
+    event DepositedToStrategy(uint256 indexed _timestamp, address _strategy, uint256 _amount);
+
+    /// @notice Emitted when assets are withdrawn from a strategy
+    /// @param _timestamp The timestamp of the withdrawal
+    /// @param _strategy The address of the strategy
+    /// @param _amount The amount of assets withdrawn
+    event WithdrawnFromStrategy(uint256 indexed _timestamp, address _strategy, uint256 _amount);
+    
+    /// @notice Emitted when assets were withdrawn from all strategies
+    /// @param _timestamp The timestamp of the withdrawal
+    event WithdrawnFromAllStrategies(uint256 indexed _timestamp);
+
+    /// @notice Emitted when a timelock is initiated to add a new strategy
+    /// @param _timestamp The timestamp of the timelock initiation
+    /// @param _strategy The address of the new strategy
+    event StrategyInitiated(uint256 indexed _timestamp, address _strategy);
+
+    /// @notice Emitted when a new strategy is added
+    /// @param _timestamp The timestamp of the strategy addition
+    /// @param _strategy The address of the strategy
+    event StrategyAdded(uint256 indexed _timestamp, address _strategy);
+
+    /// @notice Emitted when the timelock duration is set
+    /// @param _timestamp The timestamp of the timelock delay set
+    /// @param _delay The timelock delay
+    event TimelockDurationUpdated(uint256 indexed _timestamp, uint256 _delay);
+
+    /// @notice Emitted when the manager is set
+    /// @param _timestamp The timestamp of the manager set
+    /// @param _manager The address of the new manager
+    event ManagerUpdated(uint256 indexed _timestamp, address _manager);
+
+    /// @notice Emitted when platform overrides the active status of the AssetVault
+    /// @param _timestamp The timestamp of the active status override
+    /// @param _isStrategiesActive The new active status of the AssetVault
+    event ActiveStatusOverriden(uint256 indexed _timestamp, bool _isStrategiesActive);
+
+    /// @notice Emitted when platform overrides the blacklist status of a strategy
+    /// @param _timestamp The timestamp of the blacklist status override
+    /// @param _strategy The address of the strategy
+    /// @param _isBlacklisted The new blacklist status of the strategy
+    event BlacklistStatusOverriden(uint256 indexed _timestamp, address indexed _strategy, bool indexed _isBlacklisted);
+
+    /********************************** Errors **********************************/
+
+    error InvalidState();
+    error StrategyNonExistent();
+    error StrategyAlreadyActive();
+    error AssetDisabled();
+    error StrategyBlacklisted();
+    error NotTimelocked();
+    error TimelockNotExpired();
+    error Unauthorized();
+    error ZeroAmount()
+}

--- a/src/mainnet/target-assets/interfaces/IMetaVault.sol
+++ b/src/mainnet/target-assets/interfaces/IMetaVault.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IMetaVault {
+
+    /// @notice Enum to represent the current state of the vault
+    /// @dev INITIAL = Right after deployment, can move to `UNMANAGED` by calling 'initVault'
+    /// @dev UNMANAGED = Users are able to interact with the vault, can move to `MANAGED` by calling 'startEpoch'
+    /// @dev MANAGED = Strategies will be able to borrow & repay, can move to `UNMANAGED` by calling 'endEpoch'
+    enum State {
+        INITIAL,
+        UNMANAGED,
+        MANAGED
+    }
+
+    /********************************** View Functions **********************************/
+
+    /// @dev Returns whether the epoch is overdue or not, i.e. if the epoch has ended in the specified time
+    function isEpochOverdue() external view returns (bool);
+
+    /// @dev Returns whether all assets are back from AssetVaults or not
+    function areAssetsBack() external view returns (bool);
+
+    /// @dev Returns the address of the FortressSwap contract
+    function getSwap() external view returns (address);
+
+    /// @dev Returns true if the Vault is in an "UNMANAGED" state, false otherwise
+    function isUnmanaged() external view returns (bool);
+
+    /// @dev Returns the length of the AssetVaults array
+    function getAssetVaultsLength() external view returns (uint256);
+        
+    /********************************** Investor Functions **********************************/
+
+    /// @dev Burns half of the managers collateral + cancels the charging of performance fee for the epoch. Used in order to incentivize Vault Managers to end the epoch at the specified time
+    /// @dev Can only be called by anyone while "state" is "MANAGED" and "epochEnd" has passed
+    function executeLatenessPenalty() external;
+
+    /********************************** Manager Functions **********************************/
+
+    /// @dev Opens vault for deposits and claims and initiates an epoch. Can only be called by the Vault Manager while state is "INITIAL"
+    /// @param _configData - The encoded config data
+    function initiateVault(bytes memory _configData) external;
+
+    /// @dev Initiates the start of a new epoch. Can only be called by the Vault Manager while state is "UNMANAGED"
+    /// @param _configData - The encoded config data
+    function initiateEpoch(bytes memory _configData) external;
+
+    /// @dev Starts a new epoch. Can only be called by the Vault Manager while state is "UNMANAGED" and after the timelock has passed
+    function startEpoch() external;
+
+    /// @dev Ends the current epoch. Can only be called by the Vault Manager while state is "MANAGED" and if all assets are back
+    function endEpoch() external;
+
+    /// @dev Adds a new AssetVault. Can only be called by the Vault Manager while state is "UNMANAGED" and if FortressSwap supports the asset + asset is not blacklisted
+    /// @param _asset - The address of the asset (ERC20 token)
+    function addAssetVault(address _asset) external returns (address _assetVault);
+
+    /// @dev Deposits assets to the AssetVault. Can only be called by the Vault Manager while state is "UNMANAGED" and if the asset is supported + not blacklisted
+    /// @param _asset - The address of the asset
+    /// @param _amount - The amount of assets to deposit
+    /// @param _minAmount - The minimum amount of VaultAsset assets to deposit
+    function depositAsset(address _asset, uint256 _amount, uint256 _minAmount) external returns (uint256);
+
+    /// @dev Withdraws assets from the AssetVault. Can only be called by the Vault Manager while state is "UNMANAGED" and if the asset is supported
+    /// @param _asset - The address of the asset
+    /// @param _amount - The amount of VaultAsset assets to withdraw
+    /// @param _minAmount - The minimum amount of assets to withdraw
+    function withdrawAsset(address _asset, uint256 _amount, uint256 _minAmount) external returns (uint256);
+
+    /// @dev Sets a new Vault Manager. Can only be called by the Vault Manager while state is "UNMANAGED"
+    /// @param _manager - The new Vault Manager
+    function updateManager(address _manager) external;
+
+    /// @dev Updates the Vault Manager's settings. Can only be called by the Vault Manager while state is "UNMANAGED"
+    /// @param _managerPerformanceFee - The new manager performance fee
+    /// @param _vaultWithdrawFee - The new vault withdraw fee
+    /// @param _collateralRequirement - The new collateral requirement
+    /// @param _performanceFeeLimit - The new performance fee limit
+    function updateManagerSettings(uint256 _managerPerformanceFee, uint256 _vaultWithdrawFee, uint256 _collateralRequirement, uint256 _performanceFeeLimit) external;
+
+    /********************************** Platform Functions **********************************/
+
+    /// @dev Charges the management fee. Can only be called by the Platform
+    function chargeManagementFee() external;
+
+    /// @dev Updates platform fees. Can only be called by the Platform while "state" is "UNMANAGED"
+    /// @param _platformFeePercentage - The new platform fee percentage
+    function updateManagementFees(uint256 _platformFeePercentage) external;
+
+    /// @dev Sets the _isDepositPaused and _isWithdrawPaused. Can only be called by the Platform
+    /// @param _isDepositPaused - Whether to pause deposits
+    /// @param _isWithdrawPaused - Whether to pause withdrawals
+    function updatePauseInteractions(bool _isDepositPaused, bool _isWithdrawPaused) external;
+
+    /// @dev Sets some Vault settings. Can only be called by the Platform while "state" is "UNMANAGED"
+    /// @param _currentVaultState - The new Vault state
+    /// @param _swap - The new FortressSwap address
+    /// @param _depositLimit - The new deposit cap
+    /// @param _timelockDuration - The new timelock delay
+    function updatePlatformSettings(State _currentVaultState, address _swap, uint256 _depositLimit, uint256 _timelockDuration) external;
+
+    /// @dev Blacklists an asset. Can only be called by the Platform while "state" is "UNMANAGED"
+    /// @param _asset - The address of the asset to blacklist
+    function blacklistAsset(address _asset) external;
+
+    /********************************** Events **********************************/
+
+    /// @notice emitted when a deposit is made
+    /// @param _caller - The address of the depositor
+    /// @param _receiver - The address of the receiver of shares
+    /// @param _assets - The amount of assets deposited
+    /// @param _shares - The amount of shares received
+    event Deposited(address indexed _caller, address indexed _receiver, uint256 _assets, uint256 _shares);
+
+    /// @notice emitted when a withdraw is made
+    /// @param _caller - The address of the withdrawer
+    /// @param _receiver - The address of the receiver of assets
+    /// @param _owner - The address if the owner of shares
+    /// @param _assets - The amount of assets withdrawn
+    /// @param _shares - The amount of shares burned
+    event Withdrawn(address indexed _caller, address indexed _receiver, address indexed _owner, uint256 _assets, uint256 _shares);
+
+    /// @notice emitted when "setManagementFees" function is called
+    /// @param _platformManagementFee - The new platform management fee percentage
+    event ManagementFeeUpdated(uint256 _platformManagementFee);
+
+    /// @notice emitted when "updatePauseInteraction" function is called
+    /// @param _pauseDeposit - Whether to pause deposits
+    /// @param _pauseWithdraw - Whether to pause withdrawals
+    event PauseInteractionsUpdated(bool _pauseDeposit, bool _pauseWithdraw);
+
+    /// @notice emitted when "updateSettings" function is called
+    /// @param _state - The new Vault state
+    /// @param _swap - The new FortressSwap address
+    /// @param _depositCap - The new deposit cap
+    /// @param _delay - The new timelock delay
+    event SettingsUpdated(State _state, address _swap, uint256 _depositCap, uint256 _delay);
+
+    /// @notice emitted when "blacklistAsset" function is called
+    /// @param _asset - The address of the asset to blacklist
+    event AssetBlacklisted(address indexed _asset);
+
+    /// @notice emitted when "updateManager" function is called
+    /// @param _manager - The new Vault Manager
+    event ManagerUpdated(address indexed _manager);
+
+    /// @notice emitted when "executeLatenessPenalty" function is called
+    /// @param _timestamp - The timestamp at call time
+    /// @param _burnAmount - The amount of shares burned
+    event LatenessPenalty(uint256 indexed _timestamp, uint256 _burnAmount);
+
+    /// @notice emitted when "setPauseInteraction" function is called
+    /// @param _pauseDeposit - The new pauseDeposit status
+    /// @param _pauseWithdraw - The new pauseWithdraw status
+    event PauseInteractions(bool _pauseDeposit, bool _pauseWithdraw);
+
+    /// @notice emitted when "chargeManagementFee" function is called
+    /// @param _feeAmount - The amount of fee charged
+    /// @param _timestamp - The timestamp at call time
+    event ManagementFeeCharged(uint256 indexed _timestamp, uint256 _feeAmount);
+
+    /// @notice emitted when "requestStartEpoch" function is called
+    /// @param _timestamp - The timestamp at call time
+    /// @param _configData - The config data for the new epoch
+    event EpochInitiated(uint256 indexed _timestamp, bytes _configData);
+
+    /// @notice emitted when an epoch has ended
+    /// @param _timestamp The timestamp of epoch end (indexed)
+    /// @param _blockNumber The block number of epoch end (indexed)
+    /// @param _assetBalance The asset balance at this time
+    /// @param _shareSupply The share balance at this time
+    event EpochCompleted(uint256 indexed _timestamp, uint256 indexed _blockNumber, uint256 _assetBalance, uint256 _shareSupply);
+
+    /// @notice emitted when an epoch has started
+    /// @param _timestamp The timestamp of epoch start (indexed)
+    /// @param _assetBalance The asset balance at this time
+    /// @param _shareSupply The share balance at this time
+    event EpochStarted(uint256 indexed _timestamp, uint256 _assetBalance, uint256 _shareSupply);
+
+    /// @notice emitted when a new AssetVault is added
+    /// @param _assetVault The address of the new AssetVault
+    /// @param _asset The address of the asset
+    event AssetVaultAdded(address indexed _assetVault, address indexed _asset);
+
+    /// @notice emitted when a deposit is made to an AssetVault
+    /// @param _assetVault The address of the AssetVault
+    /// @param _asset The address of the asset
+    /// @param _amount The amount of AssetVault assets deposited
+    event AssetDeposited(address indexed _assetVault, address indexed _asset, uint256 _amount);
+
+    /// @notice emitted when a withdraw is made from an AssetVault
+    /// @param _assetVault The address of the AssetVault
+    /// @param _asset The address of the asset
+    /// @param _amount The amount of assets withdrawn
+    event AssetWithdrawn(address indexed _assetVault, address indexed _asset, uint256 _amount);
+
+    /// @notice emitted when a manager fee is charged
+    /// @param _managerFee The amount of fee charged
+    /// @param _postEpochBalance The balance before the start of the epoch
+    /// @param _preEpochBalance The balance after the end of the epoch
+    event FeesCharged(uint256 _managerFee, uint256 _postEpochBalance, uint256 _preEpochBalance);
+
+    /// @notice emitted when manager settings are updated
+    /// @param _managerPerformanceFee The new manager performance fee
+    /// @param _vaultWithdrawFee The new vault withdraw fee
+    /// @param _collateralRequirement The new collateral requirement
+    /// @param _performanceFeeLimit The new performance fee limit
+    event ManagerSettingsUpdated(uint256 _managerPerformanceFee, uint256 _vaultWithdrawFee, uint256 _collateralRequirement, uint256 _performanceFeeLimit);
+
+    /// @notice emitted when vault balance snapshot is taken
+    /// @param _timestamp The snapshot timestamp (indexed)
+    /// @param _blockNumber The snapshot block number (indexed)
+    /// @param _assetBalance The asset balance at this time
+    /// @param _shareSupply The share balance at this time
+    event Snapshot(uint256 indexed _timestamp, uint256 indexed _blockNumber, uint256 _assetBalance, uint256 _shareSupply);
+
+    /********************************** Errors **********************************/
+
+    error InvalidState();
+    error InvalidAmount();
+    error DepositPaused();
+    error WithdrawPaused();
+    error DepositLimitExceeded();
+    error ZeroAmount();
+    error ZeroAddress();
+    error InsufficientBalance();
+    error InsufficientCollateral();
+    error InsufficientAllowance();
+    error InsufficientAmountOut();
+    error InsufficientManagerCollateral();
+    error LatenessNotPenalized();
+    error EpochNotCompleted();
+    error InvalidSwapRoute();
+    error BlacklistedAsset();
+    error AssetVaultNotAvailable();
+    error NotTimelocked();
+    error TimelockNotExpired();
+    error Unauthorized();
+    error AssetsNotBack();
+    error EpochEndBlockInvalid();
+    error ManagerPerformanceFeeInvalid();
+    error VaultWithdrawFeeInvalid();
+    error CollateralRequirementInvalid();
+    error PlatformManagementFeeInvalid();
+    error PerformanceFeeLimitInvalid();
+    error EpochAlreadyInitiated();
+    error platformManagementFeeInvalid();
+    error ManagementFeeNotDue();
+}

--- a/src/mainnet/target-assets/interfaces/ISTETH.sol
+++ b/src/mainnet/target-assets/interfaces/ISTETH.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IWSTETH {
+    function getStETHByWstETH(uint256 _amount) external view returns (uint256);
+
+    function getWstETHByStETH(uint256 _amount) external view returns (uint256);
+
+    function stEthPerToken() external view returns (uint256);
+
+    function tokensPerStEth() external view returns (uint256);
+
+    function stETH() external view returns (address);
+
+    function wrap(uint256 _amount) external returns (uint256);
+
+    function unwrap(uint256 _amount) external returns (uint256);
+
+    function approve(address _recipient, uint256 _amount)
+        external
+        returns (bool);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
+
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    function decimals() external view returns (uint256);
+}
+
+interface ISTETH {
+    function getBufferedEther(uint256 _amount) external view returns (uint256);
+
+    function getPooledEthByShares(uint256 _amount)
+        external
+        view
+        returns (uint256);
+
+    function getSharesByPooledEth(uint256 _amount)
+        external
+        view
+        returns (uint256);
+
+    function submit(address _referralAddress)
+        external
+        payable
+        returns (uint256);
+
+    function withdraw(uint256 _amount, bytes32 _pubkeyHash)
+        external
+        returns (uint256);
+
+    function approve(address _recipient, uint256 _amount)
+        external
+        returns (bool);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
+
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    function decimals() external view returns (uint256);
+
+    function getTotalShares() external view returns (uint256);
+
+    function getTotalPooledEther() external view returns (uint256);
+}

--- a/src/mainnet/target-assets/interfaces/IWETH.sol
+++ b/src/mainnet/target-assets/interfaces/IWETH.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * MIT License
+ * ===========
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ */
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IWETH is IERC20 {
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
+
+    function deposit() external payable;
+
+    function withdraw(uint256 wad) external;
+}

--- a/src/mainnet/target-assets/stETHAssetVault.sol
+++ b/src/mainnet/target-assets/stETHAssetVault.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// ███████╗░█████╗░██████╗░████████╗██████╗░███████╗░██████╗░██████╗
+// ██╔════╝██╔══██╗██╔══██╗╚══██╔══╝██╔══██╗██╔════╝██╔════╝██╔════╝
+// █████╗░░██║░░██║██████╔╝░░░██║░░░██████╔╝█████╗░░╚█████╗░╚█████╗░
+// ██╔══╝░░██║░░██║██╔══██╗░░░██║░░░██╔══██╗██╔══╝░░░╚═══██╗░╚═══██╗
+// ██║░░░░░╚█████╔╝██║░░██║░░░██║░░░██║░░██║███████╗██████╔╝██████╔╝
+// ╚═╝░░░░░░╚════╝░╚═╝░░╚═╝░░░╚═╝░░░╚═╝░░╚═╝╚══════╝╚═════╝░╚═════╝░
+// ███████╗██╗███╗░░██╗░█████╗░███╗░░██╗░█████╗░███████╗
+// ██╔════╝██║████╗░██║██╔══██╗████╗░██║██╔══██╗██╔════╝
+// █████╗░░██║██╔██╗██║███████║██╔██╗██║██║░░╚═╝█████╗░░
+// ██╔══╝░░██║██║╚████║██╔══██║██║╚████║██║░░██╗██╔══╝░░
+// ██║░░░░░██║██║░╚███║██║░░██║██║░╚███║╚█████╔╝███████╗
+// ╚═╝░░░░░╚═╝╚═╝░░╚══╝╚═╝░░╚═╝╚═╝░░╚══╝░╚════╝░╚══════╝
+
+
+// Github - https://github.com/FortressFinance
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {ISTETH, IWSTETH} from "./interfaces/ISTETH.sol";
+import {IMetaVault} from "./interfaces/IMetaVault.sol";
+import {IAssetVault} from "./interfaces/IAssetVault.sol";
+
+contract StETHAssetVault is ReentrancyGuard, IAssetVault {
+
+    using SafeERC20 for ERC20;
+
+    /// @notice The metaVault that manages this vault
+    address public metaVault;
+    /// @notice The platform address
+    address public platform;
+    /// @notice Enables Platform to override isStrategiesActive value
+    bool public isActiveOverride = true;
+
+    /// @notice The address of WETH token.
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    /// @notice The address of WSTETH token.
+    address internal constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
+    /// @notice The address of STETH token.
+    address internal constant STETH = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
+
+    /********************************** Constructor **********************************/
+    
+    constructor(address _metaVault, address _platform) {
+        metaVault = _metaVault;
+        platform = _platform;
+    }
+
+    /********************************** Modifiers **********************************/
+
+    modifier onlyPlatform() {
+        if (msg.sender != platform) revert Unauthorized();
+        _;
+    }
+
+    /// @notice Platform has admin access
+    modifier onlyMetaVault {
+        if (msg.sender != metaVault && msg.sender != platform) revert Unauthorized();
+        _;
+    }
+
+    /********************************** View Functions **********************************/
+
+    /// @inheritdoc IAssetVault
+    function isActive() external view returns (bool) {
+        return ERC20(WSTETH).balanceOf(address(this)) > 0 || areStrategiesActive();
+    }
+
+    /// @inheritdoc IAssetVault
+    function getPrimaryAsset() external view returns (address) {
+        return WSTETH;
+    }
+
+    function getPrimaryAssetBalance() external view returns (uint256) {
+        return ERC20(WSTETH).balanceOf(address(this));
+    }
+
+    function getEthBalance() external view returns (uint256) {
+        return IWstETH(WSTETH).getStETHByWstETH(getPrimaryAssetBalance());
+    }
+
+    /********************************** Meta Vault Functions **********************************/
+
+    /// @inheritdoc IAssetVault
+    function deposit(uint256 _amount) external onlyMetaVault nonReentrant returns (uint256 _amountIn) {
+        ERC20(WETH).safeTransferFrom(_metaVault, address(this), _amount);
+
+        if (!(ERC20(WETH).balanceOf(address(this))>0)) revert ZeroAmount();
+
+        uint256 ethBalance = IWETH(WETH).withdraw(wethBalance);
+
+        uint256 amountStEthSharesOut = IStETH(STETH).submit{ value: ethBalance }(address(0));
+        uint256 amountStETH = IStETH(STETH).getPooledEthByShares(amountStEthSharesOut);
+        _amountIn = IWstETH(WSTETH).wrap(amountStETH);
+
+        emit Deposited(block.timestamp, _amount, _amountIn);
+
+        return _amountIn;
+    }
+
+    /// @inheritdoc IAssetVault
+    /// @notice WIP
+    function withdraw(uint256 _amount) public onlyMetaVault nonReentrant returns (uint256 _amountOut) {
+        if (!(ERC20(WSTETH).balanceOf(address(this))>0)) revert ZeroAmount();
+
+        uint256 _amountStEth = IWstETH(WSTETH).unwrap(amountStETH);
+        
+        // stETH -> WETH conversion logic here
+
+        // ERC20(WETH).safeTransfer(_metaVault, _amountOut);
+        // emit Withdrawn(block.timestamp, _amountOut);
+        
+        return _amountOut;
+    }
+
+    /********************************** Platform Functions **********************************/
+
+    /// @inheritdoc IAssetVault
+    function overrideActiveStatus(bool _isActive) external onlyPlatform {
+        isActiveOverride = _isActive;
+
+        emit ActiveStatusOverriden(block.timestamp, _isActive);
+    }
+
+}


### PR DESCRIPTION
Core design ideas:

- Each LSD vault is a separate contract, which could be added to/removed from fortETH assets list (currently I implemented stETH; frxETH is the next step);
- WETH (primary asset) is deposited to the contract and fortETH shares minted proportionally;
- When primary asset is deposited it is then distributed according to predefined weights* to different asset(LSDs) vaults (separate contract, which could be added to/removed from fortETH assets list. Currently I implemented stETH vault, next step is frxETH vault).

There are two ways we may proceed after deposit (I implemented both, but we need to choice one we want to keep):
(a) deposited assets are immediately distribute between LSDs vaults (gas expensive);
(b) deposited assets are buffered in the contract until distributeBufferedAssets() is called for some bounty (less expensive);

* Deposit weights might be changed and then two options available:
(a) previously deposited assets remain untouched and new deposits are distributed according to updated weights
(b) all asset in LSDs vaults converted to WETH and returned to fortETH contract, after they are redistributed back according to new weights (via calling redistributeAssets()).

Problems to consider: withdrawal (stETH -> ETH) is not currently available via Lido contract (https://www.coindesk.com/business/2023/04/06/lido-stakers-can-expect-ether-withdrawals-no-sooner-than-early-may/), therefore we could either wait when it become available or swap it through stETH/ETH pool (less effective due to slippage). 